### PR TITLE
1.2 Private DNS Zone の実装

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -4,23 +4,23 @@
 
 ### 1.1 基盤構築
 
-- [ ] **INFRA-001**: リソースグループの作成 (東日本リージョン)
-- [ ] **INFRA-002**: Virtual Network (VNet) の作成 (10.0.0.0/16, 東日本リージョン)
-- [ ] **INFRA-003**: AppServiceSubnet の作成 (10.0.1.0/24)
-- [ ] **INFRA-004**: PrivateEndpointSubnet の作成 (10.0.2.0/24)
-- [ ] **INFRA-005**: ApplicationGatewaySubnet の作成 (10.0.3.0/24)
-- [ ] **INFRA-006**: AppServiceSubnet NSG の作成と設定
-- [ ] **INFRA-007**: PrivateEndpointSubnet NSG の作成と設定
-- [ ] **INFRA-008**: ApplicationGatewaySubnet NSG の作成と設定
+- [x] **INFRA-001**: リソースグループの作成 (東日本リージョン)
+- [x] **INFRA-002**: Virtual Network (VNet) の作成 (10.0.0.0/16, 東日本リージョン)
+- [x] **INFRA-003**: AppServiceSubnet の作成 (10.0.1.0/24)
+- [x] **INFRA-004**: PrivateEndpointSubnet の作成 (10.0.2.0/24)
+- [x] **INFRA-005**: ApplicationGatewaySubnet の作成 (10.0.3.0/24)
+- [x] **INFRA-006**: AppServiceSubnet NSG の作成と設定
+- [x] **INFRA-007**: PrivateEndpointSubnet NSG の作成と設定
+- [x] **INFRA-008**: ApplicationGatewaySubnet NSG の作成と設定
 
 ### 1.2 Private DNS Zone
 
-- [ ] **INFRA-009**: privatelink.documents.azure.com の作成 (Cosmos DB 用)
-- [ ] **INFRA-010**: privatelink.vaultcore.azure.net の作成 (Key Vault 用)
-- [ ] **INFRA-011**: privatelink.azurecr.io の作成 (Container Registry 用, VNet 内アクセス用)
-- [ ] **INFRA-012**: privatelink.openai.azure.com の作成 (OpenAI 用)
-- [ ] **INFRA-013**: privatelink.azurewebsites.net の作成 (App Service 用)
-- [ ] **INFRA-014**: VNet と Private DNS Zone のリンク設定
+- [x] **INFRA-009**: privatelink.documents.azure.com の作成 (Cosmos DB 用)
+- [x] **INFRA-010**: privatelink.vaultcore.azure.net の作成 (Key Vault 用)
+- [x] **INFRA-011**: privatelink.azurecr.io の作成 (Container Registry 用, VNet 内アクセス用)
+- [x] **INFRA-012**: privatelink.openai.azure.com の作成 (OpenAI 用)
+- [x] **INFRA-013**: privatelink.azurewebsites.net の作成 (App Service 用)
+- [x] **INFRA-014**: VNet と Private DNS Zone のリンク設定
 
 ### 1.3 マネージド ID
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -96,3 +96,26 @@ resource "azurerm_subnet_network_security_group_association" "main" {
   subnet_id                 = azurerm_subnet.main[each.key].id
   network_security_group_id = azurerm_network_security_group.main[each.key].id
 }
+
+# INFRA-009-013: Private DNS Zoneの作成
+resource "azurerm_private_dns_zone" "main" {
+  for_each = var.private_dns_zones
+
+  name                = each.value
+  resource_group_name = azurerm_resource_group.main.name
+
+  tags = local.common_tags
+}
+
+# INFRA-014: VNetとPrivate DNS Zoneのリンク設定
+resource "azurerm_private_dns_zone_virtual_network_link" "main" {
+  for_each = var.private_dns_zones
+
+  name                  = "link-${each.key}-${var.project}-${var.environment}"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.main[each.key].name
+  virtual_network_id    = azurerm_virtual_network.main.id
+  registration_enabled  = false
+
+  tags = local.common_tags
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -242,3 +242,15 @@ variable "network_security_groups" {
     }
   }
 }
+
+variable "private_dns_zones" {
+  description = "Private DNS Zone の設定"
+  type        = map(string)
+  default = {
+    cosmos_db          = "privatelink.documents.azure.com"
+    key_vault          = "privatelink.vaultcore.azure.net"
+    container_registry = "privatelink.azurecr.io"
+    openai             = "privatelink.openai.azure.com"
+    app_service        = "privatelink.azurewebsites.net"
+  }
+}


### PR DESCRIPTION
## 概要
- docs/task.md の「1.2 Private DNS Zone」セクションの実装を行いました。
- Cosmos DB、Key Vault、Container Registry、OpenAI、App Service 用の Private DNS Zone の作成と、VNet とのリンク設定を Terraform で追加しています。

## 変更内容
- Terraform ファイルに各 Private DNS Zone のリソース定義を追加
- VNet とのリンク設定を追加

## 備考
特になし
